### PR TITLE
修正文档中配置rtmp_publish_host的错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ stream.play.hls_playback(start, end, profile="480p")
 ### Get Stream RTMP Publish URL
 
 ```python
-stream.play.rtmp_publish_host = host
+stream.publish.rtmp_publish_host = host
 
 stream.publish.url()
 ```


### PR DESCRIPTION
另外，稍微吐槽一下，现在这种配置host的方式实在是比较麻烦。。。这种host的设置不应该暴露给用户自己吧？或者说提供一个local_conf的机制允许用户覆盖就够了，但怎样也要用默认配置